### PR TITLE
Merge `js-types` into `jsrs-common`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,6 @@ name = "jsrs-common"
 version = "0.1.0"
 authors = ["Saghm Rossi <saghmrossi@gmail.com>"]
 license = "MIT"
+
+[dependencies]
+uuid = "0.1"

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,0 +1,9 @@
+use gc_error::GcError;
+use types::binding::Binding;
+use types::js_var::{JsPtrEnum, JsVar};
+
+pub trait Backend {
+    fn alloc(&mut self, var: JsVar, ptr: Option<JsPtrEnum>) -> Result<Binding, GcError>;
+    fn load(&self, bnd: &Binding) -> Result<(JsVar, Option<JsPtrEnum>), GcError>;
+    fn store(&mut self, var: JsVar, ptr: Option<JsPtrEnum>) -> Result<(), GcError>;
+}

--- a/src/gc_error.rs
+++ b/src/gc_error.rs
@@ -1,0 +1,44 @@
+use std::error::Error;
+use std::fmt;
+use std::result;
+
+use types::binding::{Binding, UniqueBinding};
+use types::js_var::{JsPtrEnum, JsVar};
+
+#[derive(Debug)]
+pub enum GcError {
+    Alloc(UniqueBinding),
+    HeapUpdate,
+    Load(Binding),
+    PtrAlloc,
+    Scope,
+    Store(JsVar, Option<JsPtrEnum>),
+}
+
+pub type Result<T> = result::Result<T, GcError>;
+
+impl fmt::Display for GcError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            GcError::Alloc(ref bnd) => write!(f, "Binding {} was already allocated, allocation failed", bnd),
+            GcError::HeapUpdate => write!(f, "Attempted update of invalid heap pointer"),
+            GcError::Load(ref bnd) => write!(f, "Lookup of binding {} failed", bnd),
+            GcError::PtrAlloc => write!(f, "Attempted allocation of bad pointer"),
+            GcError::Scope => write!(f, "Parent scope did not exist"),
+            GcError::Store(ref v, ref p) => write!(f, "Invalid store of var {:?}, ptr {:?}", v, p),
+        }
+    }
+}
+
+impl Error for GcError {
+    fn description(&self) -> &str {
+        match *self {
+            GcError::Alloc(_) => "bad alloc",
+            GcError::HeapUpdate => "bad ptr update",
+            GcError::Load(_)  => "load of invalid ID",
+            GcError::PtrAlloc => "bad ptr allocation",
+            GcError::Scope    => "no parent scope",
+            GcError::Store(_,_) => "store of invalid ID",
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate uuid;
 
 pub mod ast;
+pub mod backend;
 pub mod gc_error;
 pub mod macros;
 pub mod types;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,8 @@
+#![feature(associated_consts)]
+
+extern crate uuid;
+
 pub mod ast;
+pub mod gc_error;
 pub mod macros;
+pub mod types;

--- a/src/types/allocator.rs
+++ b/src/types/allocator.rs
@@ -1,0 +1,10 @@
+use std::fmt::Debug;
+
+use super::binding::UniqueBinding;
+use super::js_var::JsPtrEnum;
+
+pub trait Allocator {
+    type Error: Debug;
+    fn alloc(&mut self, binding: UniqueBinding, ptr: JsPtrEnum) -> Result<(), Self::Error>;
+    fn condemn(&mut self, unique: UniqueBinding) -> Result<(), Self::Error>;
+}

--- a/src/types/binding.rs
+++ b/src/types/binding.rs
@@ -1,0 +1,79 @@
+use std::fmt;
+
+use uuid::Uuid;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Binding(pub String);
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct UniqueBinding(pub String);
+
+impl Binding {
+    pub fn new(s: String) -> Self {
+        Binding(s)
+    }
+
+    pub fn mangle(b: &Self) -> Self {
+        Self::new(String::from("%---") +  &b.0 +  "---%" +
+                  &Uuid::new_v4().to_simple_string())
+    }
+
+    pub fn anon() -> Self {
+        Self::mangle(&Self::new(">anon_js_var<".to_string()))
+    }
+
+    pub fn is_anon(&self) -> bool {
+        self.0.contains(">anon_js_var<")
+    }
+}
+
+impl fmt::Display for Binding {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl UniqueBinding {
+    pub fn new(s: String) -> Self {
+        UniqueBinding(s)
+    }
+
+    pub fn mangle(b: &Binding) -> Self {
+        Self::new(String::from("%---") +  &b.0 +  "---%" +
+                  &Uuid::new_v4().to_simple_string())
+    }
+
+    pub fn mangle_str(s: &str) -> Self {
+        Self::new(String::from("%---") +  s +  "---%" +
+                  &Uuid::new_v4().to_simple_string())
+    }
+
+    pub fn anon() -> Self {
+        Self::mangle(&Binding::new(">anon_js_var<".to_string()))
+    }
+
+    pub fn is_anon(&self) -> bool {
+        self.0.contains(">anon_js_var<")
+    }
+
+    pub fn dummy() -> Self {
+        UniqueBinding("".to_owned())
+    }
+}
+
+impl fmt::Display for UniqueBinding {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display() {
+        let bnd = UniqueBinding::anon();
+        println!("{}", bnd);
+    }
+}

--- a/src/types/coerce.rs
+++ b/src/types/coerce.rs
@@ -1,0 +1,105 @@
+use std::f64::NAN;
+
+use super::js_var::{JsPtrEnum, JsPtrTag, JsType, JsVar};
+use super::js_var::JsType::*;
+
+pub trait AsBool {
+    fn as_bool(&self) -> bool;
+}
+
+impl AsBool for JsVar {
+    fn as_bool(&self) -> bool {
+        match self.t {
+            JsBool(b) => b,
+            JsUndef=> false,
+            JsNull => false,
+            JsNum(n) =>
+                if n == 0.0f64 || n == -0.0f64 || n.is_nan() {
+                    false
+                } else {
+                    true
+                },
+            JsPtr(_) => true, // TODO - this is incorrect
+            //JsString(ref s) =>
+            //    if s.len() == 0 {
+            //        false
+            //    } else {
+            //        true
+            //    },
+            //JsSymbol(_) => true,
+            //JsObject | JsError(_) | JsFunction(_, _, _) => true,
+        }
+    }
+}
+
+pub trait AsNumber {
+    fn as_number(&self) -> f64;
+}
+
+impl AsNumber for JsVar {
+    fn as_number(&self) -> f64 {
+        match self.t {
+            JsBool(b) => if b { 1f64 } else { 0f64 },
+            JsUndef => NAN,
+            JsNull => 0f64,
+            JsNum(n) => n,
+            JsPtr(_) => NAN,
+            //JsString(ref s) =>
+            //    if s.len() == 0 {
+            //        JsNumber(0f64)
+            //    } else {
+            //        let num = s.parse();
+            //        match num {
+            //            Ok(n)  => JsNumber(n),
+            //            Err(_) => JsNumber(NAN),
+            //        }
+            //    },
+            //JsSymbol(_) => panic!("Cannot convert a Symbol to a number."),
+            //JsObject | JsError(_) | JsFunction(_, _, _) => JsNumber(NAN),
+        }
+    }
+}
+
+pub trait AsString {
+    fn as_string(&self) -> String;
+}
+
+impl AsString for JsType {
+    fn as_string(&self) -> String {
+        let s = match *self {
+            JsBool(true) => "true",
+            JsBool(false) => "false",
+            JsUndef => "undefined",
+            JsNull => "null",
+            JsNum(n) => return format!("{}", n),
+
+            // NOTE: These cases should never actually be used; in the case that the variable is
+            // a JsPtr, the corresponding JsPtrEnum's string coercion should be used.
+            JsPtr(JsPtrTag::JsSym) => "Symbol(...)",
+            JsPtr(JsPtrTag::JsStr) => "\"...\"",
+            JsPtr(JsPtrTag::JsObj) => "{ ... }",
+            JsPtr(JsPtrTag::JsFn{..}) => "function() { ... }",
+            JsPtr(JsPtrTag::NativeFn{..}) => "function() { [native code] }",
+        };
+
+        String::from(s)
+    }
+}
+
+impl AsString for JsPtrEnum {
+    fn as_string(&self) -> String {
+        match *self {
+            JsPtrEnum::JsSym(ref s) => format!("Symbol({})", s),
+            JsPtrEnum::JsStr(ref s) => s.text.to_owned(),
+
+            // TODO: Check object's `toString` method
+            JsPtrEnum::JsObj(_) => String::from("[object Object]"),
+
+            // TODO: A function's string representation is apparently the string of source code that
+            // created it; the AST doesn't currently support this, so we'll need to do some
+            // restructuring before we can support this.
+            JsPtrEnum::JsFn(_) => String::from("[function]"),
+            JsPtrEnum::NativeFn(_) => String::from("[native function]"),
+        }
+    }
+}

--- a/src/types/js_fn.rs
+++ b/src/types/js_fn.rs
@@ -1,0 +1,46 @@
+use std::fmt::{Display, Formatter, Error};
+
+use ast::Stmt;
+
+// For storing functions.
+// In the future, this will have to store some sense of local variable scope,
+// to deal with closures.
+#[derive(Clone, Debug)]
+pub struct JsFnStruct {
+    pub name: Option<String>,
+    pub params: Vec<String>,
+    pub stmt: Stmt,
+}
+
+impl JsFnStruct {
+    pub fn new(name: &Option<String>, params: &Vec<String>, block: &Stmt) -> JsFnStruct {
+        JsFnStruct {
+            name: name.clone(),
+            params: params.clone(),
+            stmt: block.clone(),
+        }
+    }
+}
+
+impl Display for JsFnStruct {
+    fn fmt(&self, mut fmt: &mut Formatter) -> Result<(), Error> {
+        try!(write!(fmt, "function {}(", self.name.clone().unwrap_or(String::new())));
+
+        for (i, param) in self.params.iter().enumerate() {
+            if i != 0 {
+                try!(write!(fmt, ", "));
+            }
+
+            try!(write!(fmt, "{}", param));
+        }
+
+        try!(write!(fmt, ") {{\n"));
+        try!(self.stmt.fmt_helper(&mut fmt, 2));
+        write!(fmt, "\n}}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // TODO tests for fn objs
+}

--- a/src/types/js_obj.rs
+++ b/src/types/js_obj.rs
@@ -1,0 +1,93 @@
+use std::collections::hash_map::HashMap;
+use std::collections::hash_set::HashSet;
+use std::fmt::{Display, Formatter, Error};
+use std::string::String;
+use std::vec::Vec;
+
+use super::allocator::Allocator;
+use super::binding::UniqueBinding;
+use super::js_var::{JsVar, JsKey, JsType, JsPtrEnum};
+
+#[derive(Clone, Debug)]
+pub struct JsObjStruct {
+    pub proto: JsProto,
+    pub name: String,
+    pub dict: HashMap<JsKey, JsVar>,
+}
+
+impl JsObjStruct {
+    pub fn new<T: Allocator>(proto: JsProto, name: &str,
+                             kv_tuples: Vec<(JsKey, JsVar, Option<JsPtrEnum>)>,
+                             allocator: &mut T) -> JsObjStruct {
+        JsObjStruct {
+            proto: None,
+            name: String::from(name),
+            dict: kv_tuples.into_iter().map(|(k, v, ptr)| {
+                if let Some(ptr) = ptr {
+                    allocator.alloc(v.unique.clone(), ptr).expect("Unable to allocate!"); // TODO better error handling
+                }
+                (k, v)
+            }).collect()
+        }
+    }
+
+    pub fn add_key<T: Allocator>(&mut self, k: JsKey, v: JsVar, ptr: Option<JsPtrEnum>, allocator: &mut T) {
+        // If the key already exists, potentially condemn its pointer, which is being overwritten.
+        if let Some(var) = self.dict.get(&k) {
+            match var.t {
+                JsType::JsPtr(_) => allocator.condemn(var.unique.clone()).expect("Unable to whiten!"),
+                _ => {}
+            }
+        }
+        // Then, allocate the new pointer if necessary...
+        if let Some(ptr) = ptr {
+            allocator.alloc(v.unique.clone(), ptr).expect("Unable to allocate!"); // TODO better error handling
+        }
+        // ...and insert the key & value into the dictionary blindly.
+        self.dict.insert(k, v);
+    }
+
+    pub fn get_children(&self) -> HashSet<UniqueBinding> {
+        let mut bindings = HashSet::new();
+        for v in self.dict.values() {
+            match v.t {
+                JsType::JsPtr(_) => { bindings.insert(v.unique.clone()); },
+                _ => (),
+            }
+        }
+        bindings
+    }
+}
+
+impl Display for JsObjStruct {
+    fn fmt(&self, mut fmt: &mut Formatter) -> Result<(), Error> {
+        try!(write!(fmt, "{{ "));
+
+        for (i, (ref key, ref val)) in self.dict.iter().enumerate() {
+            if i != 0 {
+                try!(write!(fmt, ", "));
+            }
+
+            try!(write!(fmt, "{}: {}", key, val));
+        }
+
+        write!(fmt, " }}")
+    }
+}
+
+pub type JsProto = Option<Box<JsObjStruct>>;
+
+// TODO nice JS object creation macro
+//macro_rules! js_obj {
+//    ( $kt:ty : $ke:expr => $vt:ty : $ve:expr ),* {
+//        {
+//
+//        }
+//    };
+//}
+
+
+#[cfg(test)]
+mod tests {
+    // TODO tests for objs
+}

--- a/src/types/js_str.rs
+++ b/src/types/js_str.rs
@@ -1,0 +1,23 @@
+use std::fmt::{Display, Formatter, Error};
+use std::string::String;
+
+// `string`
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct JsStrStruct {
+    pub text: String,
+}
+
+impl JsStrStruct {
+    const MAX_STR_LEN: u64 = 9007199254740991; // 2^53 - 1
+
+    pub fn new(s: &str) -> JsStrStruct {
+        assert!((s.len() as u64) < JsStrStruct::MAX_STR_LEN);
+        JsStrStruct { text: s.to_string(), }
+    }
+}
+
+impl Display for JsStrStruct {
+    fn fmt(&self, mut fmt: &mut Formatter) -> Result<(), Error> {
+        write!(fmt, "{}", self.text)
+    }
+}

--- a/src/types/js_var.rs
+++ b/src/types/js_var.rs
@@ -43,6 +43,16 @@ impl JsVar {
         var
     }
 
+    pub fn deanonymize(&mut self, binding: &str) -> bool {
+        if self.binding.is_anon() {
+            self.unique = UniqueBinding::mangle_str(binding);
+            self.binding = Binding::new(binding.to_owned());
+            true
+        } else {
+            false
+        }
+    }
+
     pub fn type_of(&self) -> String {
         self.t.type_of()
     }

--- a/src/types/js_var.rs
+++ b/src/types/js_var.rs
@@ -1,0 +1,187 @@
+use std::fmt::{Display, Formatter, Error};
+use std::hash::{Hash, Hasher};
+use std::string::String;
+
+use super::binding::{Binding, UniqueBinding};
+use super::coerce::AsString;
+use super::js_fn::JsFnStruct;
+use super::js_obj::JsObjStruct;
+use super::js_str::JsStrStruct;
+use super::native_fn::NativeFn;
+
+#[derive(Clone, Debug)]
+pub struct JsVar {
+    pub unique: UniqueBinding,
+    pub binding: Binding,
+    pub t: JsType,
+}
+
+impl Hash for JsVar {
+    fn hash<H>(&self, state: &mut H) where H: Hasher {
+        self.unique.hash(state);
+    }
+}
+
+impl JsVar {
+    pub fn new(t: JsType) -> JsVar {
+        let mut var = JsVar {
+            unique: UniqueBinding::dummy(),
+            binding: Binding::anon(),
+            t: t,
+        };
+        var.unique = UniqueBinding::mangle(&var.binding);
+        var
+    }
+
+    pub fn bind(binding: &str, t: JsType) -> JsVar {
+        let mut var = JsVar {
+            unique: UniqueBinding::mangle_str(binding),
+            binding: Binding::new(binding.to_owned()),
+            t: t,
+        };
+        var.unique = UniqueBinding::mangle(&var.binding);
+        var
+    }
+
+    pub fn type_of(&self) -> String {
+        self.t.type_of()
+    }
+}
+
+impl Display for JsVar {
+    fn fmt(&self, mut fmt: &mut Formatter) -> Result<(), Error> {
+        if !self.binding.is_anon() {
+            return write!(fmt, "{}", self.binding);
+        }
+
+        write!(fmt, "{}", self.t)
+    }
+}
+
+impl PartialEq for JsVar {
+    fn eq(&self, other: &Self) -> bool {
+        self.unique == other.unique
+    }
+
+    fn ne(&self, other: &Self) -> bool {
+        !self.eq(other)
+    }
+}
+
+impl Eq for JsVar {}
+
+#[derive(Clone, Debug)]
+pub enum JsPtrEnum {
+    JsSym(String),
+    JsStr(JsStrStruct),
+    JsObj(JsObjStruct),
+    JsFn(JsFnStruct),
+    NativeFn(NativeFn),
+}
+
+impl Display for JsPtrEnum {
+    fn fmt(&self, mut fmt: &mut Formatter) -> Result<(), Error> {
+        match self {
+            &JsPtrEnum::JsSym(ref s) => write!(fmt, "Symbol({})", s),
+            &JsPtrEnum::JsStr(ref s) => write!(fmt, "\"{}\"", s),
+            &JsPtrEnum::JsObj(ref o) => write!(fmt, "{}", o),
+            &JsPtrEnum::JsFn(ref f) => write!(fmt, "{}", f),
+            &JsPtrEnum::NativeFn(_) => write!(fmt, "[native code]"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum JsPtrTag {
+    JsSym,
+    JsStr,
+    JsObj,
+    JsFn { name: Option<String> },
+    NativeFn { name: String },
+}
+
+impl JsPtrTag {
+    pub fn eq_ptr_type(&self, other: &JsPtrEnum) -> bool {
+        match (self, other) {
+            (&JsPtrTag::JsSym, &JsPtrEnum::JsSym(_)) |
+            (&JsPtrTag::JsStr, &JsPtrEnum::JsStr(_)) |
+            (&JsPtrTag::JsObj, &JsPtrEnum::JsObj(_)) |
+            (&JsPtrTag::JsFn{..},  &JsPtrEnum::JsFn(_)) |
+            (&JsPtrTag::NativeFn{..}, &JsPtrEnum::NativeFn(_)) => true,
+            _ => false
+        }
+    }
+
+    fn type_of(&self) -> String {
+        let s = match *self {
+            JsPtrTag::JsSym => "symbol",
+            JsPtrTag::JsStr => "string",
+            JsPtrTag::JsObj => "object",
+            JsPtrTag::JsFn{..} | JsPtrTag::NativeFn{..} => "function",
+        };
+
+        String::from(s)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum JsType {
+    JsUndef,
+    JsNum(f64),
+    JsBool(bool),
+    JsPtr(JsPtrTag),
+    JsNull, // null is not a ptr since it doesn't actually require heap allocation
+}
+
+impl JsType {
+    fn type_of(&self) -> String {
+        let s = match *self {
+            JsType::JsUndef => "undefined",
+            JsType::JsNum(_) => "number",
+            JsType::JsBool(_) => "boolean",
+            JsType::JsNull => "object",
+            JsType::JsPtr(ref t) => return t.type_of(),
+        };
+
+        String::from(s)
+    }
+}
+
+impl Display for JsType {
+    fn fmt(&self, mut fmt: &mut Formatter) -> Result<(), Error> {
+        write!(fmt, "{}", self.as_string())
+    }
+}
+
+impl PartialEq for JsType {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (&JsType::JsUndef, &JsType::JsUndef) => true,
+            (&JsType::JsNum(x), &JsType::JsNum(y)) => x == y,
+            (&JsType::JsBool(b1), &JsType::JsBool(b2)) => b1 == b2,
+            (&JsType::JsNull, &JsType::JsNull) => true,
+            (_, _) => false,
+        }
+    }
+
+    fn ne(&self, other: &Self) -> bool {
+        !self.eq(other)
+    }
+}
+
+impl Eq for JsType {}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub enum JsKey {
+    JsStr(JsStrStruct),
+    JsSym(String),
+}
+
+impl Display for JsKey {
+    fn fmt(&self, mut fmt: &mut Formatter) -> Result<(), Error> {
+        match *self {
+            JsKey::JsStr(ref s) => write!(fmt, "{}", s),
+            JsKey::JsSym(ref s) => write!(fmt, "Symbol({})", s),
+        }
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,0 +1,8 @@
+pub mod allocator;
+pub mod binding;
+pub mod coerce;
+pub mod js_obj;
+pub mod js_str;
+pub mod js_var;
+pub mod js_fn;
+pub mod native_fn;

--- a/src/types/native_fn.rs
+++ b/src/types/native_fn.rs
@@ -5,7 +5,7 @@ use super::binding::Binding;
 use super::js_var::{JsPtrEnum, JsVar};
 
 pub trait JsScope {
-    fn alloc(&mut self, var: JsVar);
+    fn alloc(&mut self, var: JsVar, ptr: Option<JsPtrEnum>) -> Result<Binding, GcError>;
     fn load(&self, bnd: &Binding) -> Result<(JsVar, Option<JsPtrEnum>), GcError>;
     fn store(&mut self, var: JsVar, ptr: Option<JsPtrEnum>) -> Result<(), GcError>;
 }

--- a/src/types/native_fn.rs
+++ b/src/types/native_fn.rs
@@ -1,0 +1,20 @@
+use std::fmt::{self, Formatter, Debug};
+
+use gc_error::GcError;
+use super::binding::Binding;
+use super::js_var::{JsPtrEnum, JsVar};
+
+pub trait JsScope {
+    fn alloc(&mut self, var: JsVar);
+    fn load(&self, bnd: &Binding) -> Result<(JsVar, Option<JsPtrEnum>), GcError>;
+    fn store(&mut self, var: JsVar, ptr: Option<JsPtrEnum>) -> Result<(), GcError>;
+}
+
+#[derive(Clone)]
+pub struct NativeFn(fn(Box<JsScope>, Vec<JsVar>) -> JsVar);
+
+impl Debug for NativeFn {
+    fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
+        write!(fmt, "[native_code]")
+    }
+}

--- a/src/types/native_fn.rs
+++ b/src/types/native_fn.rs
@@ -1,17 +1,10 @@
 use std::fmt::{self, Formatter, Debug};
 
-use gc_error::GcError;
-use super::binding::Binding;
+use backend::Backend;
 use super::js_var::{JsPtrEnum, JsVar};
 
-pub trait JsScope {
-    fn alloc(&mut self, var: JsVar, ptr: Option<JsPtrEnum>) -> Result<Binding, GcError>;
-    fn load(&self, bnd: &Binding) -> Result<(JsVar, Option<JsPtrEnum>), GcError>;
-    fn store(&mut self, var: JsVar, ptr: Option<JsPtrEnum>) -> Result<(), GcError>;
-}
-
 #[derive(Clone)]
-pub struct NativeFn(fn(Box<JsScope>, Vec<(JsVar, Option<JsPtrEnum>)>) -> JsVar);
+pub struct NativeFn(fn(Box<Backend>, Vec<(JsVar, Option<JsPtrEnum>)>) -> JsVar);
 
 impl Debug for NativeFn {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {

--- a/src/types/native_fn.rs
+++ b/src/types/native_fn.rs
@@ -1,18 +1,20 @@
+use std::cell::RefCell;
 use std::fmt::{self, Formatter, Debug};
+use std::rc::Rc;
 
 use backend::Backend;
 use super::js_var::{JsPtrEnum, JsVar};
 
 #[derive(Clone)]
-pub struct NativeFn(fn(Box<Backend>, Vec<(JsVar, Option<JsPtrEnum>)>) -> (JsVar, Option<JsPtrEnum>));
+pub struct NativeFn(fn(Rc<RefCell<Backend>>, Vec<(JsVar, Option<JsPtrEnum>)>) -> (JsVar, Option<JsPtrEnum>));
 
 impl NativeFn {
-    pub fn new(func: fn(Box<Backend>, Vec<(JsVar, Option<JsPtrEnum>)>) -> (JsVar, Option<JsPtrEnum>)) -> NativeFn 
+    pub fn new(func: fn(Rc<RefCell<Backend>>, Vec<(JsVar, Option<JsPtrEnum>)>) -> (JsVar, Option<JsPtrEnum>)) -> NativeFn
 {
       NativeFn(func)
     }
 
-    pub fn call(&self, backend: Box<Backend>, args: Vec<(JsVar, Option<JsPtrEnum>)>) -> (JsVar, 
+    pub fn call(&self, backend: Rc<RefCell<Backend>>, args: Vec<(JsVar, Option<JsPtrEnum>)>) -> (JsVar,
 Option<JsPtrEnum>) {
         self.0(backend, args)
     }

--- a/src/types/native_fn.rs
+++ b/src/types/native_fn.rs
@@ -7,9 +7,10 @@ use super::js_var::{JsPtrEnum, JsVar};
 pub struct NativeFn(fn(Box<Backend>, Vec<(JsVar, Option<JsPtrEnum>)>) -> (JsVar, Option<JsPtrEnum>));
 
 impl NativeFn {
-  fn new(func: fn(Box<Backend>, Vec<(JsVar, Option<JsPtrEnum>)>) -> (JsVar, Option<JsPtrEnum>)) -> NativeFn {
-    NativeFn(func)
-  }
+    pub fn new(func: fn(Box<Backend>, Vec<(JsVar, Option<JsPtrEnum>)>) -> (JsVar, Option<JsPtrEnum>)) -> NativeFn 
+{
+      NativeFn(func)
+    }
 }
 
 impl Debug for NativeFn {

--- a/src/types/native_fn.rs
+++ b/src/types/native_fn.rs
@@ -11,6 +11,11 @@ impl NativeFn {
 {
       NativeFn(func)
     }
+
+    pub fn call(&self, backend: Box<Backend>, args: Vec<(JsVar, Option<JsPtrEnum>)>) -> (JsVar, 
+Option<JsPtrEnum>) {
+        self.0(backend, args)
+    }
 }
 
 impl Debug for NativeFn {

--- a/src/types/native_fn.rs
+++ b/src/types/native_fn.rs
@@ -4,7 +4,13 @@ use backend::Backend;
 use super::js_var::{JsPtrEnum, JsVar};
 
 #[derive(Clone)]
-pub struct NativeFn(fn(Box<Backend>, Vec<(JsVar, Option<JsPtrEnum>)>) -> JsVar);
+pub struct NativeFn(fn(Box<Backend>, Vec<(JsVar, Option<JsPtrEnum>)>) -> (JsVar, Option<JsPtrEnum>));
+
+impl NativeFn {
+  fn new(func: fn(Box<Backend>, Vec<(JsVar, Option<JsPtrEnum>)>) -> (JsVar, Option<JsPtrEnum>)) -> NativeFn {
+    NativeFn(func)
+  }
+}
 
 impl Debug for NativeFn {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {

--- a/src/types/native_fn.rs
+++ b/src/types/native_fn.rs
@@ -11,7 +11,7 @@ pub trait JsScope {
 }
 
 #[derive(Clone)]
-pub struct NativeFn(fn(Box<JsScope>, Vec<JsVar>) -> JsVar);
+pub struct NativeFn(fn(Box<JsScope>, Vec<(JsVar, Option<JsPtrEnum>)>) -> JsVar);
 
 impl Debug for NativeFn {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {


### PR DESCRIPTION
Merging is necessary so that the `JsScope` trait can have access to `GcError`, which needs access to `JsVar`, `JsPtrEnum`, `Binding`, and `UniqueBinding`.

Pull requests are also made to `french-press` and `js.rs` to fix the issues with imports that will result from merging this.
